### PR TITLE
[2ndSeminar] 2차 세미나 과제

### DIFF
--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/MemberController.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/MemberController.java
@@ -1,0 +1,48 @@
+package org.sopt.secondSeminar.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.dto.MemberCreateDto;
+import org.sopt.secondSeminar.dto.MemberDetailDto;
+import org.sopt.secondSeminar.dto.MemberFindDto;
+import org.sopt.secondSeminar.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<Void> createMember(
+            @RequestBody MemberCreateDto memberCreate
+    ) {
+        return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<MemberFindDto> findMemberById(
+            @PathVariable Long memberId
+    ) {
+      return ResponseEntity.ok(memberService.findMemberById(memberId));
+    }
+
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> deleteMemberById(
+            @PathVariable Long memberId
+    ) {
+        memberService.deleteMemberById(memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<MemberDetailDto>> findAllMembers() {
+        return ResponseEntity.ok(memberService.findAllMembers());
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Member.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Member.java
@@ -21,11 +21,13 @@ public class Member {
 
     private int age;
 
+    private Member(String name, Part part, int age) {
+        this.name = name;
+        this.part = part;
+        this.age = age;
+    }
+
     public static Member create(String name, Part part, int age) {
-        Member member = new Member();
-        member.name = name;
-        member.part = part;
-        member.age = age;
-        return member;
+        return new Member(name, part, age);
     }
 }

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Member.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Member.java
@@ -1,0 +1,31 @@
+package org.sopt.secondSeminar.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.secondSeminar.domain.enums.Part;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Part part;
+
+    private int age;
+
+    public static Member create(String name, Part part, int age) {
+        Member member = new Member();
+        member.name = name;
+        member.part = part;
+        member.age = age;
+        return member;
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/enums/Part.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/enums/Part.java
@@ -8,5 +8,4 @@ public enum Part {
     IOS,
     DESIGN,
     PLAN
-    ;
 }

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/enums/Part.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/enums/Part.java
@@ -1,0 +1,12 @@
+package org.sopt.secondSeminar.domain.enums;
+
+public enum Part {
+
+    SERVER,
+    WEB,
+    ANDROID,
+    IOS,
+    DESIGN,
+    PLAN
+    ;
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberCreateDto.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberCreateDto.java
@@ -1,0 +1,10 @@
+package org.sopt.secondSeminar.dto;
+
+import org.sopt.secondSeminar.domain.enums.Part;
+
+public record MemberCreateDto(
+        String name,
+        Part part,
+        int age
+) {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberDetailDto.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberDetailDto.java
@@ -1,0 +1,23 @@
+package org.sopt.secondSeminar.dto;
+
+import org.sopt.secondSeminar.domain.Member;
+import org.sopt.secondSeminar.domain.enums.Part;
+
+public record MemberDetailDto(
+        Long id,
+        String name,
+        Part part,
+        int age
+) {
+
+    public static MemberDetailDto of(
+            Member member
+    ) {
+        return new MemberDetailDto(
+                member.getId(),
+                member.getName(),
+                member.getPart(),
+                member.getAge()
+        );
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberFindDto.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/MemberFindDto.java
@@ -1,0 +1,20 @@
+package org.sopt.secondSeminar.dto;
+
+import org.sopt.secondSeminar.domain.Member;
+import org.sopt.secondSeminar.domain.enums.Part;
+
+public record MemberFindDto(
+        String name,
+        Part part,
+        int age
+) {
+    public static MemberFindDto of(
+            Member member
+    ) {
+        return new MemberFindDto(
+                member.getName(),
+                member.getPart(),
+                member.getAge()
+        );
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.secondSeminar.repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.sopt.secondSeminar.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    default Member findByIdOrThrow(Long id) {
+        return findById(id).orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
@@ -3,9 +3,7 @@ package org.sopt.secondSeminar.repository;
 import jakarta.persistence.EntityNotFoundException;
 import org.sopt.secondSeminar.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member findByIdOrThrow(Long id) {

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/service/MemberService.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/service/MemberService.java
@@ -1,0 +1,41 @@
+package org.sopt.secondSeminar.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.domain.Member;
+import org.sopt.secondSeminar.dto.MemberCreateDto;
+import org.sopt.secondSeminar.dto.MemberDetailDto;
+import org.sopt.secondSeminar.dto.MemberFindDto;
+import org.sopt.secondSeminar.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public String createMember(MemberCreateDto memberCreateDto) {
+        Member member = Member.create(memberCreateDto.name(), memberCreateDto.part(), memberCreateDto.age());
+        memberRepository.save(member);
+        return member.getId().toString();
+    }
+
+    public MemberFindDto findMemberById(Long memberId) {
+        return MemberFindDto.of(memberRepository.findByIdOrThrow(memberId));
+
+    }
+
+    public void deleteMemberById(Long memberId) {
+        memberRepository.delete(memberRepository.findByIdOrThrow(memberId));
+    }
+
+    public List<MemberDetailDto> findAllMembers() {
+        return memberRepository.findAll().stream()
+                .map(MemberDetailDto::of)
+                .toList();
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/service/MemberService.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/service/MemberService.java
@@ -1,6 +1,5 @@
 package org.sopt.secondSeminar.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.sopt.secondSeminar.domain.Member;
 import org.sopt.secondSeminar.dto.MemberCreateDto;

--- a/secondSeminar/src/test/java/org/sopt/secondSeminar/controller/MemberControllerTest.java
+++ b/secondSeminar/src/test/java/org/sopt/secondSeminar/controller/MemberControllerTest.java
@@ -1,0 +1,53 @@
+package org.sopt.secondSeminar.controller;
+
+import io.restassured.RestAssured;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.secondSeminar.dto.MemberCreateDto;
+import org.sopt.secondSeminar.repository.MemberRepository;
+import org.sopt.secondSeminar.service.MemberService;
+import org.sopt.secondSeminar.settings.ApiTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.sopt.secondSeminar.domain.enums.Part.SERVER;
+
+public class MemberControllerTest extends ApiTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Nested // 중첩 테스트를 진행할 수 있게하는 테스트
+    @DisplayName("멤버 생성 테스트")
+    public class CreateMember {
+
+        @Test
+        @DisplayName("요청 성공 케이스")
+        public void createMemberSuccess() throws Exception {
+            //given
+            final var request = new MemberCreateDto(
+                    "박상준",
+                    SERVER,
+                    20);
+            //when
+            final var response = RestAssured
+                    .given()
+                    .log().all()
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .body(request)
+                    .when()
+                    .post("/api/v1/members")
+                    .then().log().all().extract();
+            //then
+            Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        }
+
+    }
+
+}

--- a/secondSeminar/src/test/java/org/sopt/secondSeminar/settings/ApiTest.java
+++ b/secondSeminar/src/test/java/org/sopt/secondSeminar/settings/ApiTest.java
@@ -1,0 +1,18 @@
+package org.sopt.secondSeminar.settings;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class ApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach //각 테스트 진행 전 실행
+    void setUp() {
+        RestAssured.port = port;
+    }
+}


### PR DESCRIPTION
## ⌛*NOW SOPT 2차 과제*

### 📟 관련 이슈
- Resolved: #3 

### 💻 과제 내용
- REST API에서 일반적으로 사용되는 복수형으로 endpoint를 변경하였습니다. (`members`)
- MemberRepository에서 default 메소드를 생성해서 오류처리를 하였습니다.
- Member Entity에서 정적 팩토리 메소드만을 사용하게 하였습니다.
- Part ENUM을 domain 내 enums 패키지에 분리하였습니다.
- Member 목록 API를 생성하고 [API 명세](https://solstice-colby-563.notion.site/2-c3fa4d49d75242fb8630ab1043fd484f?pvs=4)를 작성하였습니다.

### 📝 리뷰 노트
N/A