### PR TITLE
[3ndSeminar] 3차 세미나 과제

### DIFF
--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/common/ErrorResponse.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/common/ErrorResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.secondSeminar.common;
+
+import org.sopt.secondSeminar.exception.ErrorMessage;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+
+    public static ErrorResponse of(ErrorMessage errorMessage) {
+        return new ErrorResponse(errorMessage.getStatus(), errorMessage.getMessage());
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/common/GlobalExceptionHandler.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/common/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package org.sopt.secondSeminar.common;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.sopt.secondSeminar.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage()));
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/common/SuccessMessage.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/common/SuccessMessage.java
@@ -1,0 +1,16 @@
+package org.sopt.secondSeminar.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(),"블로그 생성이 완료되었습니다."),
+    POST_CREATE_SUCCESS(HttpStatus.CREATED.value(),"포스트 생성이 완료되었습니다."),
+    ;
+    private final int status;
+    private final String message;
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/BlogController.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/BlogController.java
@@ -1,0 +1,41 @@
+package org.sopt.secondSeminar.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.common.SuccessMessage;
+import org.sopt.secondSeminar.dto.BlogCreateRequest;
+import org.sopt.secondSeminar.dto.BlogTitleUpdateRequest;
+import org.sopt.secondSeminar.dto.SuccessStatusResponse;
+import org.sopt.secondSeminar.service.BlogService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class BlogController {
+
+    private final BlogService blogService;
+
+    @PostMapping("/blogs")
+    public ResponseEntity<SuccessStatusResponse> createBlog(
+            @RequestHeader Long memberId,
+            @RequestBody BlogCreateRequest blogCreateRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).header(
+                        "Location",
+                        blogService.create(memberId, blogCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));
+    }
+
+    @PatchMapping("/blogs/{blogId}/title")
+    public ResponseEntity<Void> updateBlogTitle(
+            @PathVariable Long blogId,
+            @Valid @RequestBody BlogTitleUpdateRequest blogTitleUdpateRequest
+    ) {
+        blogService.updateTitle(blogId, blogTitleUdpateRequest);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/MemberController.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/MemberController.java
@@ -13,27 +13,27 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/members")
+@RequestMapping("/api/v1")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping
+    @PostMapping("/members")
     public ResponseEntity<Void> createMember(
             @RequestBody MemberCreateDto memberCreate
     ) {
         return ResponseEntity.created(URI.create(memberService.createMember(memberCreate))).build();
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping("/members/{memberId}")
     public ResponseEntity<MemberFindDto> findMemberById(
             @PathVariable Long memberId
     ) {
-      return ResponseEntity.ok(memberService.findMemberById(memberId));
+      return ResponseEntity.ok(memberService.findMember(memberId));
     }
 
 
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping("/members/{memberId}")
     public ResponseEntity<Void> deleteMemberById(
             @PathVariable Long memberId
     ) {
@@ -41,7 +41,7 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping
+    @GetMapping("/members")
     public ResponseEntity<List<MemberDetailDto>> findAllMembers() {
         return ResponseEntity.ok(memberService.findAllMembers());
     }

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/PostController.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/controller/PostController.java
@@ -1,0 +1,39 @@
+package org.sopt.secondSeminar.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.common.SuccessMessage;
+import org.sopt.secondSeminar.dto.PostCreateRequest;
+import org.sopt.secondSeminar.dto.PostDetailDto;
+import org.sopt.secondSeminar.dto.SuccessStatusResponse;
+import org.sopt.secondSeminar.service.PostService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @PostMapping("/blogs/{blogId}/posts")
+    public ResponseEntity<SuccessStatusResponse> createPost(
+            @RequestHeader Long memberId,
+            @PathVariable Long blogId,
+            @Valid @RequestBody PostCreateRequest postCreateRequest
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).header(
+                        "Location",
+                        postService.create(memberId, blogId, postCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.POST_CREATE_SUCCESS));
+    }
+
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<PostDetailDto> getPost(
+            @PathVariable Long postId
+    ) {
+        return ResponseEntity.ok(postService.findPost(postId));
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/BaseTimeEntity.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.sopt.secondSeminar.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Blog.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Blog.java
@@ -1,0 +1,47 @@
+package org.sopt.secondSeminar.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Blog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(length = 200)
+    private String title;
+
+    private String description;
+
+    private Blog(
+            Member member,
+            String title,
+            String description
+    ) {
+        this.member = member;
+        this.title = title;
+        this.description = description;
+    }
+
+    public static Blog create(
+            Member member,
+            String title,
+            String description) {
+        return new Blog(member, title, description);
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Post.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/domain/Post.java
@@ -1,0 +1,42 @@
+package org.sopt.secondSeminar.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
+
+    private Post(
+            String title,
+            String content,
+            Blog blog
+    ) {
+        this.title = title;
+        this.content = content;
+        this.blog = blog;
+    }
+
+    public static Post create(
+            Blog blog,
+            String title,
+            String content
+    ) {
+        return new Post(title, content, blog);
+    }
+
+
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/BlogCreateRequest.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/BlogCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.secondSeminar.dto;
+
+public record BlogCreateRequest(
+        String title,
+        String description
+) {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/BlogTitleUpdateRequest.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/BlogTitleUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.secondSeminar.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record BlogTitleUpdateRequest(
+        @Size(max = 5 , message = "블로그 제목이 최대 글자 수(5자)를 초과했습니다.")
+        String title
+) {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/PostCreateRequest.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/PostCreateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.secondSeminar.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PostCreateRequest(
+        @NotBlank String title,
+        @NotBlank String content
+) {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/PostDetailDto.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/PostDetailDto.java
@@ -1,0 +1,17 @@
+package org.sopt.secondSeminar.dto;
+
+import org.sopt.secondSeminar.domain.Post;
+
+public record PostDetailDto(
+        Long id,
+        String title,
+        String content
+) {
+    public static PostDetailDto of(Post post) {
+        return new PostDetailDto(
+                post.getId(),
+                post.getTitle(),
+                post.getContent()
+        );
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/SuccessStatusResponse.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/dto/SuccessStatusResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.secondSeminar.dto;
+
+import org.sopt.secondSeminar.common.SuccessMessage;
+
+public record SuccessStatusResponse(
+        int status,
+        String message
+) {
+
+    public static SuccessStatusResponse of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage());
+    }
+
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/BusinessException.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package org.sopt.secondSeminar.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private ErrorMessage errorMessage;
+
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/ErrorMessage.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/ErrorMessage.java
@@ -1,0 +1,20 @@
+package org.sopt.secondSeminar.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorMessage {
+    MEMBER_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
+    BLOG_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
+    BLOG_PERMISSION_DENIED(HttpStatus.FORBIDDEN.value(), "해당 블로그의 주인이 아닙니다."),
+    POST_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
+    POST_NOT_IN_BLOG_EXCEPTION(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 게시글이 존재하지 않습니다."),
+
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/ForbiddenException.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package org.sopt.secondSeminar.exception;
+
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/NotFoundException.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package org.sopt.secondSeminar.exception;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/BlogRepository.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/BlogRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.secondSeminar.repository;
+
+import org.sopt.secondSeminar.domain.Blog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogRepository extends JpaRepository<Blog, Long> {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/MemberRepository.java
@@ -5,8 +5,4 @@ import org.sopt.secondSeminar.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
-    default Member findByIdOrThrow(Long id) {
-        return findById(id).orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
-    }
 }

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/PostRepository.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.secondSeminar.repository;
+
+import org.sopt.secondSeminar.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/service/BlogService.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/service/BlogService.java
@@ -1,0 +1,49 @@
+package org.sopt.secondSeminar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.domain.Blog;
+import org.sopt.secondSeminar.domain.Member;
+import org.sopt.secondSeminar.dto.BlogCreateRequest;
+import org.sopt.secondSeminar.dto.BlogTitleUpdateRequest;
+import org.sopt.secondSeminar.exception.ErrorMessage;
+import org.sopt.secondSeminar.exception.ForbiddenException;
+import org.sopt.secondSeminar.repository.BlogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+
+    private final BlogRepository blogRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public String create(Long memberId, BlogCreateRequest createRequest) {
+        Member member = memberService.findMemberById(memberId);
+        Blog blog = blogRepository.save(Blog.create(member, createRequest.title(), createRequest.description()));
+        return blog.getId().toString();
+    }
+
+    @Transactional
+    public void updateTitle(
+            Long blogId,
+            BlogTitleUpdateRequest blogTitleUpdateRequest
+    ) {
+        Blog blog = findBlogById(blogId);
+        blog.updateTitle(blogTitleUpdateRequest.title());
+    }
+
+    public void checkBlogMember(Long blogId, Long memberId) {
+        Blog blog = findBlogById(blogId);
+        if (!blog.getMember().getId().equals(memberId)) {
+            throw new IllegalArgumentException("해당 블로그의 작성자가 아닙니다.");
+        }
+    }
+
+    public Blog findBlogById(Long blogId) {
+        return blogRepository.findById(blogId)
+                .orElseThrow(() -> new ForbiddenException(ErrorMessage.BLOG_PERMISSION_DENIED));
+    }
+
+}

--- a/secondSeminar/src/main/java/org/sopt/secondSeminar/service/PostService.java
+++ b/secondSeminar/src/main/java/org/sopt/secondSeminar/service/PostService.java
@@ -1,0 +1,41 @@
+package org.sopt.secondSeminar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.secondSeminar.domain.Post;
+import org.sopt.secondSeminar.dto.PostCreateRequest;
+import org.sopt.secondSeminar.dto.PostDetailDto;
+import org.sopt.secondSeminar.exception.ErrorMessage;
+import org.sopt.secondSeminar.exception.NotFoundException;
+import org.sopt.secondSeminar.repository.PostRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final BlogService blogService;
+
+    @Transactional
+    public String create(Long memberId, Long blogId, PostCreateRequest postCreateRequest) {
+        blogService.checkBlogMember(blogId, memberId);
+        return postRepository.save(
+                Post.create(
+                        blogService.findBlogById(blogId),
+                        postCreateRequest.title(),
+                        postCreateRequest.content()
+                        )
+        ).getId().toString();
+    }
+
+    @Transactional(readOnly = true)
+    public PostDetailDto findPost(Long postId) {
+        return PostDetailDto.of(findPostById(postId));
+    }
+
+    public Post findPostById(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.POST_NOT_FOUND_BY_ID_EXCEPTION));
+    }
+}

--- a/secondSeminar/src/test/java/org/sopt/secondSeminar/controller/BlogControllerTest.java
+++ b/secondSeminar/src/test/java/org/sopt/secondSeminar/controller/BlogControllerTest.java
@@ -1,0 +1,69 @@
+package org.sopt.secondSeminar.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.secondSeminar.dto.BlogCreateRequest;
+import org.sopt.secondSeminar.repository.BlogRepository;
+import org.sopt.secondSeminar.repository.MemberRepository;
+import org.sopt.secondSeminar.service.BlogService;
+import org.sopt.secondSeminar.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BlogController.class) //SpringBootTest로 서버를 구동시키는 대신 Controller 계층만 테스트
+@AutoConfigureMockMvc //Spring Boot 테스트에서 MockMvc를 사용하기 위한 설정을 자동으로 제공하는 어노테이션
+public class BlogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /*
+    BlogRepository -> BlogService -> MemberService -> MemberRepository
+                                                                -> BlogRepository
+    */
+    @SpyBean
+    private BlogService blogService;
+
+    @SpyBean
+    private MemberService memberService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private BlogRepository blogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper; //생성하는 객체를 String JSON 배열로 바꾸기 위해 사용
+
+    @Nested
+    class createBlog {
+        @Test
+        @DisplayName("Blog 생성 실패 테스트")
+        public void createBlogFail() throws Exception {
+
+            //given
+            String request = objectMapper.writeValueAsString(new BlogCreateRequest("tkdwns414 블로그", "블로그입니다."));
+
+            //when
+            mockMvc.perform(
+                            post("/api/v1/blog")
+                                    .content(request).header("memberId", 2)
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound()) //생성 실패 시나리오로 NotFound가 돌아오는 상황을 테스트
+                    .andDo(print()); // 끝난 후 모든 결과를 출력
+
+        }
+    }
+}


### PR DESCRIPTION
## ⌛*NOW SOPT N차 과제*

### 📟 관련 이슈
- Resolved: #7 

### 💻 과제 내용
<!-- 과제 내용을 자유롭게 적어주세요. -->
- 한 도메인의 서비스에서 다른 도메인의 Repository를 불러오는 것을 방지하고자 findById 관련 에러 처리를 모두 Service로 뺐습니다.
- 정적 팩토리 메소드만들 사용하는 것을 보장하기 위해 생성자를 private로 바꿨습니다
- 과제 관련 API를 생성하고 [API 명세](https://solstice-colby-563.notion.site/2-c3fa4d49d75242fb8630ab1043fd484f?pvs=4)를 작성하였습니다.

### 📝 리뷰 노트
<!-- 질문이나 리뷰어들이 특별히 더 봐줬으면 하는 사항이 있다면 적어주세요. -->
- 글을 작성하는 경우에는 {어떤} 블로그에 속한 글을 작성하겠다고 식별하는 값이므로 PathVariable에 들어가는 것이 어울리는 값 같습니다.
- 반면 글을 조회하는 경우에는 블로그와 관련된 내용은 없어도 글의 pk값만 있으면 조회할 수 있으므로 블로그 아이디는 포함하지 않았습니다.
- 여유가 더 있다면 블로그마다 고유의 pk를 가지는 설계를 해보고 싶습니다.
- 바빠서 미루다가 마지막 즈음에 우다다해서 낸 과제라 실수가 있을지도 모르겠습니다.